### PR TITLE
Actually use DOTFILES_CONFIG_DIR for configuration 

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -14,7 +14,12 @@ DOTFILES_INSTALL_PATH="${1:-${DOTFILES_INSTALL_PATH:-${HOME}}}"
 export DOTFILES_INSTALL_PATH="$(realpath "${DOTFILES_INSTALL_PATH}")"
 export DOTFILES_CONFIG_DIR="${DOTFILES_INSTALL_PATH}/.dotfiles-config"
 
-[ -d "${DOTFILES_CONFIG_DIR}" ] || mkdir "${DOTFILES_CONFIG_DIR}"
+if [ ! -d "${DOTFILES_CONFIG_DIR}" ]
+then
+    mkdir "${DOTFILES_CONFIG_DIR}"
+    echo "First time dotfiles-builder is run."
+    echo "You will need to import your configurations."
+fi
 
 for configure in "${DOTFILES_DIR}/configure"/*.sh; do
     . "${configure}"

--- a/install.sh
+++ b/install.sh
@@ -41,4 +41,4 @@ function recursive_install() {
 }
 
 
-recursive_install "${DOTFILES_INSTALL_PATH}" "${DOTFILES_DIR}/dotfiles"
+recursive_install "${DOTFILES_INSTALL_PATH}" "${DOTFILES_CONFIG_DIR}/dotfiles"


### PR DESCRIPTION
Up to now, the config in .dotfiles-config was ignored and the repo embeded config was always use instead.
I also added a warning in case of empty/new config
